### PR TITLE
Add variable to override when Celery starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An Ansible role for installing [Celery](http://www.celeryproject.org/).
 - `celery_version` - Celery version
 - `celery_dir` - Directory for Celery worker to execute from (default: `/var/lib/celery`)
 - `celery_bin` - Path to Celery binary (default: `/usr/local/bin/celery`)
+- `celery_start_on` - Upstart `start on` stanza (default: `local-filesystems and net-device-up IFACE!=lo`)
 - `celery_app` - Celery application name (default: `proj`)
 - `celery_broker_url` - Celery broker URL (default: `redis://localhost:6379/0`)
 - `celery_log_level` - Celery worker log level (default: `info`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 celery_version: "3.1.17"
 celery_dir: "/var/lib/celery"
 celery_bin: "/usr/local/bin/celery"
+celery_start_on: "local-filesystems and net-device-up IFACE!=lo"
 celery_app: "proj"
 celery_broker_url: "redis://localhost:6379/0"
 celery_log_level: "info"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -3,6 +3,7 @@
 
   vars:
     celery_dir: "/opt/app"
+    celery_start_on: "vagrant-mounted"
 
   pre_tasks:
     - name: Update APT cache

--- a/templates/celery.conf.j2
+++ b/templates/celery.conf.j2
@@ -1,6 +1,6 @@
 description	"celery"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on ({{ celery_start_on }})
 stop on shutdown
 
 respawn


### PR DESCRIPTION
Add the `celery_start_on` variable to override the `start on` Upstart stanza.
