### PR TITLE
Add support for auto reloading Celery daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vagrant
+*.retry
 
 examples/roles/azavea.pip
 examples/roles/azavea.redis

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Celery](http://www.celeryproject.org/).
 ## Role Variables
 
 - `celery_version` - Celery version
+- `celery_autoreload` - Flag to enable or disable auto-reloading (default: `False`)
 - `celery_dir` - Directory for Celery worker to execute from (default: `/var/lib/celery`)
 - `celery_bin` - Path to Celery binary (default: `/usr/local/bin/celery`)
 - `celery_start_on` - Upstart `start on` stanza (default: `local-filesystems and net-device-up IFACE!=lo`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ celery_start_on: "local-filesystems and net-device-up IFACE!=lo"
 celery_app: "proj"
 celery_broker_url: "redis://localhost:6379/0"
 celery_log_level: "info"
+celery_autoreload: False
 
 celery_log: "/var/log/celery.log"
 celery_log_rotate_count: 5

--- a/examples/demoapp/requirements.txt
+++ b/examples/demoapp/requirements.txt
@@ -1,1 +1,1 @@
-Django>=1.7.2
+Django>=1.8

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -4,6 +4,7 @@
   vars:
     celery_dir: "/opt/app"
     celery_start_on: "vagrant-mounted"
+    celery_autoreload: True
 
   pre_tasks:
     - name: Update APT cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 - name: Create service account for Celery
   user: name=celery
         system=yes
-        home={{ celery_dir }}
+        home="{{ celery_dir }}"
         shell=/bin/false
         state=present
 
 - name: Install Celery
-  pip: name="celery[redis]" version={{ celery_version }} state=present
+  pip: name="celery[redis]" version="{{ celery_version }}" state=present
 
 - name: Configure Celery service definition
   template: src=celery.conf.j2 dest=/etc/init/celery.conf
@@ -18,7 +18,7 @@
   copy: content="" dest="{{ celery_log }}" force=no
 
 - name: Set log file permissions
-  file: path={{ celery_log }} owner=celery group=celery mode=0644
+  file: path="{{ celery_log }}" owner=celery group=celery mode=0644
 
 - name: Configure Celery log rotation
   template: src=logrotate_celery.j2 dest=/etc/logrotate.d/celery

--- a/templates/celery.conf.j2
+++ b/templates/celery.conf.j2
@@ -7,5 +7,8 @@ respawn
 setuid celery
 chdir {{ celery_dir }}
 
-exec {{ celery_bin }} -A "{{ celery_app }}" -b "{{ celery_broker_url }}" \
-    worker -l {{ celery_log_level }} >> {{ celery_log }} 2>&1
+exec {{ celery_bin }} \
+    -A "{{ celery_app }}" \
+    -b "{{ celery_broker_url }}" \
+    worker -l {{ celery_log_level }} \
+    {{ '--autoreload' if celery_autoreload else '' }} >> {{ celery_log }} 2>&1


### PR DESCRIPTION
Using the `celery_autoreload` variable, configure Celery to automatically reload when code changes are detected.

---

**Testing**

First, provision the example Vagrant virtual machine:

``` bash
$ cd examples
$ vagrant up
```

Then, `tail` the Celery log and make a change to a Celery task in the included demo application to see if it triggers a reloading event in the logs:

``` bash
$ vagrant ssh -c "tail -f /var/log/celery.log"
[2016-07-12 13:48:51,646: WARNING/MainProcess] celery@vagrant-ubuntu-trusty-64 ready.
[2016-07-12 13:51:37,839: INFO/MainProcess] Detected modified modules: ['demoapp.tasks']
```
